### PR TITLE
Update Examples and Apps to SK v0.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Now close and reopen Visual Studio Code, this time opening the `semantic-kernel-
 1. Open a terminal window, change to the directory with your Azure Function project file (e.g., `semantic-kernel-rag-chat/src/myfunc`), 
     and run the `dotnet` command below to add the Semantic Kernel NuGet package to your project.
     ```bash
-    dotnet add package Microsoft.SemanticKernel --prerelease -v dotnet-0.24.230918.1-preview
+    dotnet add package Microsoft.SemanticKernel -v 0.24.230918.1-preview
     ```
 
     In addition, use the commands below to configure .NET User Secrets and then securely store your OpenAI API key.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Now close and reopen Visual Studio Code, this time opening the `semantic-kernel-
 1. Open a terminal window, change to the directory with your Azure Function project file (e.g., `semantic-kernel-rag-chat/src/myfunc`), 
     and run the `dotnet` command below to add the Semantic Kernel NuGet package to your project.
     ```bash
-    dotnet add package Microsoft.SemanticKernel --prerelease -v 0.14.547.1-preview
+    dotnet add package Microsoft.SemanticKernel --prerelease -v dotnet-0.24.230918.1-preview
     ```
 
     In addition, use the commands below to configure .NET User Secrets and then securely store your OpenAI API key.
@@ -96,9 +96,7 @@ Now close and reopen Visual Studio Code, this time opening the `semantic-kernel-
 
             IKernel kernel = new KernelBuilder()
                 .WithLogger(sp.GetRequiredService<ILogger<IKernel>>())
-                .Configure(config => config.AddOpenAIChatCompletionService(
-                    modelId: "gpt-3.5-turbo",
-                    apiKey: openAiApiKey))
+                .WithOpenAIChatCompletionService("gpt-3.5-turbo", openAiApiKey)
                 .Build();
 
             return kernel;
@@ -300,7 +298,7 @@ Before you get started, make sure you have the following additional requirements
 1. Open a terminal window, change to the directory with your project file (e.g., `semantic-kernel-rag-chat/src/myfunc`), 
    and run the `dotnet` command below to add the Semantic Kernel Qdrant Memory Store to your project.
     ```bash
-    dotnet add package Microsoft.SemanticKernel.Connectors.Memory.Qdrant --prerelease -v 0.14.547.1-preview
+    dotnet add package Microsoft.SemanticKernel.Connectors.Memory.Qdrant --prerelease -v dotnet-0.24.230918.1-preview
     ```
 
 1. Open your Program code file (e.g., `Program.cs`) and add the Qdrant memory store using statement to the top.
@@ -640,7 +638,7 @@ Before you get started, make sure you have the following additional requirements
 1. Open a terminal window, change to the directory with your project file (e.g., `semantic-kernel-rag-chat/src/myfunc`), 
    and run the `dotnet` command below to add the Semantic Kernel Azure Cognitive Search connector to your project.
     ```bash
-    dotnet add package Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch --prerelease -v 0.14.547.1-preview
+    dotnet add package Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch --prerelease -v dotnet-0.24.230918.1-preview
     ```
 
     In addition, use the `dotnet user-secrets` commands below to securely store your Azure Cognitive Search API key and endpoint URL.

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ Before you get started, make sure you have the following additional requirements
 1. Open a terminal window, change to the directory with your project file (e.g., `semantic-kernel-rag-chat/src/myfunc`), 
    and run the `dotnet` command below to add the Semantic Kernel Azure Cognitive Search connector to your project.
     ```bash
-    dotnet add package Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch --prerelease -v dotnet-0.24.230918.1-preview
+    dotnet add package Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch -v 0.24.230918.1-preview
     ```
 
     In addition, use the `dotnet user-secrets` commands below to securely store your Azure Cognitive Search API key and endpoint URL.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Now close and reopen Visual Studio Code, this time opening the `semantic-kernel-
             string openAiApiKey = configuration["OPENAI_APIKEY"];
 
             IKernel kernel = new KernelBuilder()
-                .WithLogger(sp.GetRequiredService<ILogger<IKernel>>())
+                .WithLoggerFactory(sp.GetRequiredService<ILoggerFactory>())
                 .WithOpenAIChatCompletionService("gpt-3.5-turbo", openAiApiKey)
                 .Build();
 
@@ -177,10 +177,10 @@ Now close and reopen Visual Studio Code, this time opening the `semantic-kernel-
 
             // Construct a semantic kernel and connect the OpenAI chat completion APIs.
             IKernel kernel = new KernelBuilder()
-                .WithLogger(sp.GetRequiredService<ILogger<IKernel>>())
-                .Configure(config => config.AddOpenAIChatCompletionService(
-                    modelId: "gpt-3.5-turbo",
-                    apiKey: openAiApiKey))
+                .WithLoggerFactory(sp.GetRequiredService<ILoggerFactory>())
+                .WithOpenAIChatCompletionService(
+                    "gpt-3.5-turbo",
+                    openAiApiKey)
                 .Build();
 
             return kernel;
@@ -318,13 +318,13 @@ Before you get started, make sure you have the following additional requirements
         logger: sp.GetRequiredService<ILogger<QdrantMemoryStore>>());
 
      IKernel kernel = new KernelBuilder()
-        .WithLogger(sp.GetRequiredService<ILogger<IKernel>>())
-        .Configure(config => config.AddOpenAIChatCompletionService(
-            modelId: "gpt-3.5-turbo",
-            apiKey: openAiApiKey))
-        .Configure(c => c.AddOpenAITextEmbeddingGenerationService(
-            modelId: "text-embedding-ada-002",
-            apiKey: openAiApiKey))
+        .WithLoggerFactory(sp.GetRequiredService<ILoggerFactory>())
+        .WithOpenAIChatCompletionService(
+            "gpt-3.5-turbo",
+            openAiApiKey)
+        .WithOpenAITextEmbeddingGenerationService(
+            "text-embedding-ada-002",
+            openAiApiKey)
         .WithMemoryStorage(memoryStore)
         .Build();
     ```
@@ -429,23 +429,27 @@ Before you get started, make sure you have the following additional requirements
             // Retrieve the OpenAI API key from the configuration.
             IConfiguration configuration = sp.GetRequiredService<IConfiguration>();
             string openAiApiKey = configuration["OPENAI_APIKEY"];
+            string qdrantEndpoint = configuration["QDRANT_ENDPOINT"] ?? "";
+
+            Uri qdrantUri = new Uri(qdrantEndpoint);
+
 
             // Create a memory store that will be used to store memories.
             QdrantMemoryStore memoryStore = new QdrantMemoryStore(
-               host: "http://localhost",
-               port: 6333,
-               vectorSize: 1536,
-               logger: sp.GetRequiredService<ILogger<QdrantMemoryStore>>());
+                endpoint: $"{qdrantUri.Scheme}://{qdrantUri.Host}:{qdrantUri.Port}",
+                vectorSize: 1536,
+                loggerFactory: sp.GetRequiredService<ILoggerFactory>()
+            );
 
             // Create the kerne with chat completion, embedding generation, and memory storage.
             IKernel kernel = new KernelBuilder()
-                .WithLogger(sp.GetRequiredService<ILogger<IKernel>>())
-                .Configure(config => config.AddOpenAIChatCompletionService(
-                    modelId: "gpt-3.5-turbo",
-                    apiKey: openAiApiKey))
-                .Configure(c => c.AddOpenAITextEmbeddingGenerationService(
-                    modelId: "text-embedding-ada-002",
-                    apiKey: openAiApiKey))
+                .WithLoggerFactory(sp.GetRequiredService<ILoggerFactory>())
+                .WithOpenAIChatCompletionService(
+                    "gpt-3.5-turbo",
+                    openAiApiKey)
+                .WithOpenAITextEmbeddingGenerationService(
+                    "text-embedding-ada-002",
+                    openAiApiKey)
                 .WithMemoryStorage(memoryStore)
                 .Build();
 
@@ -665,10 +669,10 @@ Before you get started, make sure you have the following additional requirements
 
     ```csharp
     IKernel kernel = new KernelBuilder()
-        .WithLogger(sp.GetRequiredService<ILogger<IKernel>>())
-        .Configure(config => config.AddOpenAIChatCompletionService(
-            modelId: "gpt-3.5-turbo",
-            apiKey: openAiApiKey))
+        .WithLoggerFactory(sp.GetRequiredService<ILoggerFactory>())
+        .WithOpenAIChatCompletionService(
+            "gpt-3.5-turbo",
+            openAiApiKey)
         .WithMemory(memory)
         .Build();
     ```
@@ -712,10 +716,10 @@ Before you get started, make sure you have the following additional requirements
 
             // Create the kernel with chat completion and memory.
             IKernel kernel = new KernelBuilder()
-                .WithLogger(sp.GetRequiredService<ILogger<IKernel>>())
-                .Configure(config => config.AddOpenAIChatCompletionService(
-                    modelId: "gpt-3.5-turbo",
-                    apiKey: openAiApiKey))
+                .WithLoggerFactory(sp.GetRequiredService<ILoggerFactory>())
+                .WithOpenAIChatCompletionService(
+                    "gpt-3.5-turbo",
+                    openAiApiKey)
                 .WithMemory(memory)
                 .Build();
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Before you get started, make sure you have the following additional requirements
 1. Open a terminal window, change to the directory with your project file (e.g., `semantic-kernel-rag-chat/src/myfunc`), 
    and run the `dotnet` command below to add the Semantic Kernel Qdrant Memory Store to your project.
     ```bash
-    dotnet add package Microsoft.SemanticKernel.Connectors.Memory.Qdrant --prerelease -v dotnet-0.24.230918.1-preview
+    dotnet add package Microsoft.SemanticKernel.Connectors.Memory.Qdrant -v 0.24.230918.1-preview
     ```
 
 1. Open your Program code file (e.g., `Program.cs`) and add the Qdrant memory store using statement to the top.

--- a/src/chapter1/Chapter1Function.cs
+++ b/src/chapter1/Chapter1Function.cs
@@ -24,11 +24,11 @@ namespace My.Chapter1
         {
             _logger.LogInformation("C# HTTP trigger function processed a request.");
 
-            _chatHistory!.AddMessage(ChatHistory.AuthorRoles.User, await req.ReadAsStringAsync() ?? string.Empty);
+            _chatHistory!.AddMessage(AuthorRole.User, await req.ReadAsStringAsync() ?? string.Empty);
 
             string reply = await _chat.GenerateMessageAsync(_chatHistory, new ChatRequestSettings());
 
-            _chatHistory.AddMessage(ChatHistory.AuthorRoles.Assistant, reply);
+            _chatHistory.AddMessage(AuthorRole.Assistant, reply);
 
             HttpResponseData response = req.CreateResponse(HttpStatusCode.OK);
             response.WriteString(reply);

--- a/src/chapter1/Program.cs
+++ b/src/chapter1/Program.cs
@@ -18,13 +18,11 @@ hostBuilder.ConfigureServices(services =>
     services.AddSingleton<IKernel>(sp =>
     {
         IConfiguration configuration = sp.GetRequiredService<IConfiguration>();
-        string openAiApiKey = configuration["OPENAI_APIKEY"];
+        string openAiApiKey = configuration["OPENAI_APIKEY"] ?? "";
 
         IKernel kernel = new KernelBuilder()
-            .WithLogger(sp.GetRequiredService<ILogger<IKernel>>())
-            .Configure(config => config.AddOpenAIChatCompletionService(
-                modelId: "gpt-3.5-turbo",
-                apiKey: openAiApiKey))
+            .WithLoggerFactory(sp.GetRequiredService<ILoggerFactory>())
+            .WithOpenAIChatCompletionService("gpt-3.5-turbo", openAiApiKey)
             .Build();
 
         return kernel;

--- a/src/chapter1/chapter1.csproj
+++ b/src/chapter1/chapter1.csproj
@@ -8,11 +8,11 @@
     <UserSecretsId>semantic-kernel-rag-chat</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.13.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.14.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="0.14.547.1-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="0.24.230918.1-preview" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/chapter2/Chapter2Function.cs
+++ b/src/chapter2/Chapter2Function.cs
@@ -29,13 +29,13 @@ namespace My.MyChatFunction
         {
             _logger.LogInformation("C# HTTP trigger function processed a request.");
 
-            _chatHistory!.AddMessage(ChatHistory.AuthorRoles.User, await req.ReadAsStringAsync() ?? string.Empty);
+            _chatHistory!.AddMessage(AuthorRole.User, await req.ReadAsStringAsync() ?? string.Empty);
             //string message = await SearchMemoriesAsync(_kernel, await req.ReadAsStringAsync() ?? string.Empty);
-            //_chatHistory!.AddMessage(ChatHistory.AuthorRoles.User, message);
+            //_chatHistory!.AddMessage(AuthorRole.User, message);
 
             string reply = await _chat.GenerateMessageAsync(_chatHistory, new ChatRequestSettings());
 
-            _chatHistory.AddMessage(ChatHistory.AuthorRoles.Assistant, reply);
+            _chatHistory.AddMessage(AuthorRole.Assistant, reply);
 
             HttpResponseData response = req.CreateResponse(HttpStatusCode.OK);
             response.WriteString(reply);

--- a/src/chapter2/chapter2.csproj
+++ b/src/chapter2/chapter2.csproj
@@ -12,8 +12,9 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.9.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="0.14.547.1-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.Qdrant" Version="0.14.547.1-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="0.24.230918.1-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.AI.OpenAI" Version="0.24.230918.1-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.Qdrant" Version="0.24.230918.1-preview" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/chapter3/Chapter3Function.cs
+++ b/src/chapter3/Chapter3Function.cs
@@ -29,13 +29,13 @@ namespace My.MyChatFunction
         {
             _logger.LogInformation("C# HTTP trigger function processed a request.");
 
-            //_chatHistory!.AddMessage(ChatHistory.AuthorRoles.User, await req.ReadAsStringAsync() ?? string.Empty);
+            //_chatHistory!.AddMessage(AuthorRole.User, await req.ReadAsStringAsync() ?? string.Empty);
             string message = await SearchMemoriesAsync(_kernel, await req.ReadAsStringAsync() ?? string.Empty);
-            _chatHistory!.AddMessage(ChatHistory.AuthorRoles.User, message);
+            _chatHistory!.AddMessage(AuthorRole.User, message);
 
             string reply = await _chat.GenerateMessageAsync(_chatHistory, new ChatRequestSettings());
 
-            _chatHistory.AddMessage(ChatHistory.AuthorRoles.Assistant, reply);
+            _chatHistory.AddMessage(AuthorRole.Assistant, reply);
 
             HttpResponseData response = req.CreateResponse(HttpStatusCode.OK);
             response.WriteString(reply);

--- a/src/chapter3/Program.cs
+++ b/src/chapter3/Program.cs
@@ -19,19 +19,21 @@ hostBuilder.ConfigureServices(services =>
     services.AddSingleton<IKernel>(sp =>
     {
         IConfiguration configuration = sp.GetRequiredService<IConfiguration>();
-        string openAiApiKey = configuration["OPENAI_APIKEY"];
+        string openAiApiKey = configuration["OPENAI_APIKEY"] ?? "";
+        string azureCognitiveSearchUrl = configuration["AZURE_COGNITIVE_SEARCH_URL"] ?? "";
+        string azureCognitiveSearchApiKey = configuration["AZURE_COGNITIVE_SEARCH_APIKEY"] ?? "";
 
-        AzureCognitiveSearchMemory memory = new AzureCognitiveSearchMemory(
-            configuration["AZURE_COGNITIVE_SEARCH_URL"],
-            configuration["AZURE_COGNITIVE_SEARCH_APIKEY"]
+        AzureCognitiveSearchMemoryStore memory = new AzureCognitiveSearchMemoryStore(
+            azureCognitiveSearchUrl,
+            azureCognitiveSearchApiKey
         );
 
         IKernel kernel = new KernelBuilder()
-            .WithLogger(sp.GetRequiredService<ILogger<IKernel>>())
-            .Configure(config => config.AddOpenAIChatCompletionService(
-                modelId: "gpt-3.5-turbo",
-                apiKey: openAiApiKey))
-            .WithMemory(memory)
+            .WithLoggerFactory(sp.GetRequiredService<ILoggerFactory>())
+            .WithOpenAIChatCompletionService(
+                "gpt-3.5-turbo",
+                openAiApiKey)
+            .WithMemoryStorage(memory)
             .Build();
 
         return kernel;

--- a/src/chapter3/chapter3.csproj
+++ b/src/chapter3/chapter3.csproj
@@ -12,8 +12,9 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.9.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="0.14.547.1-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch" Version="0.14.547.1-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="0.24.230918.1-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.AI.OpenAI" Version="0.24.230918.1-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch" Version="0.24.230918.1-preview" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/chapter3/chapter3.sln
+++ b/src/chapter3/chapter3.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "chapter3", "chapter3.csproj", "{4EE2B46F-F1D6-4E36-9C82-9A205790763E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4EE2B46F-F1D6-4E36-9C82-9A205790763E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4EE2B46F-F1D6-4E36-9C82-9A205790763E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4EE2B46F-F1D6-4E36-9C82-9A205790763E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4EE2B46F-F1D6-4E36-9C82-9A205790763E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2F5D92C4-E438-4427-BFF2-1EFCAF7BAC1A}
+	EndGlobalSection
+EndGlobal

--- a/src/importmemories/Program.cs
+++ b/src/importmemories/Program.cs
@@ -69,7 +69,7 @@ internal class Program
 
             // Create a new kernel with an OpenAI Embedding Generation service.
             kernel = new KernelBuilder()
-                .WithMemory(memory)
+                .WithMemoryStorage(memory)
                 .Build();
         }
         else

--- a/src/importmemories/Program.cs
+++ b/src/importmemories/Program.cs
@@ -55,6 +55,7 @@ internal class Program
         {
             // Get the Azure Cognitive Search API key from the environment.
             string? azureCognitiveSearchApiKey = config["AZURE_COGNITIVE_SEARCH_APIKEY"];
+            string? openAiApiKey = config["OPENAI_APIKEY"];
 
             if (string.IsNullOrWhiteSpace(azureCognitiveSearchApiKey))
             {
@@ -69,6 +70,7 @@ internal class Program
 
             // Create a new kernel with an OpenAI Embedding Generation service.
             kernel = new KernelBuilder()
+                .WithOpenAITextEmbeddingGenerationService("text-embedding-ada-002", openAiApiKey)
                 .WithMemoryStorage(memory)
                 .Build();
         }

--- a/src/importmemories/Program.cs
+++ b/src/importmemories/Program.cs
@@ -46,9 +46,7 @@ internal class Program
 
             // Create a new kernel with an OpenAI Embedding Generation service.
             kernel = new KernelBuilder()
-                .Configure(c => c.AddOpenAITextEmbeddingGenerationService(
-                    modelId: "text-embedding-ada-002",
-                    apiKey: openAiApiKey))
+                .WithOpenAITextEmbeddingGenerationService("text-embedding-ada-002", openAiApiKey)
                 .WithMemoryStorage(memoryStore)
                 .Build();
 

--- a/src/importmemories/Program.cs
+++ b/src/importmemories/Program.cs
@@ -62,7 +62,7 @@ internal class Program
                 return;
             }
 
-            AzureCognitiveSearchMemory memory = new AzureCognitiveSearchMemory(
+            AzureCognitiveSearchMemoryStore memory = new AzureCognitiveSearchMemoryStore(
                 memoryUrl,
                 azureCognitiveSearchApiKey
             );

--- a/src/importmemories/Program.cs
+++ b/src/importmemories/Program.cs
@@ -41,8 +41,7 @@ internal class Program
             // Create a new memory store that will store the embeddings in Qdrant.
             Uri qdrantUri = new Uri(memoryUrl);
             QdrantMemoryStore memoryStore = new QdrantMemoryStore(
-                host: $"{qdrantUri.Scheme}://{qdrantUri.Host}",
-                port: qdrantUri.Port,
+                endpoint: $"{qdrantUri.Scheme}://{qdrantUri.Host}:{qdrantUri.Port}",
                 vectorSize: 1536);
 
             // Create a new kernel with an OpenAI Embedding Generation service.

--- a/src/importmemories/importmemories.csproj
+++ b/src/importmemories/importmemories.csproj
@@ -12,9 +12,9 @@
     <PackageReference Include="BlingFireNuget" Version="0.1.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="0.13.442.1-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.Qdrant" Version="0.13.442.1-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch" Version="0.13.442.1-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="0.24.230912.2-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.Qdrant" Version="0.24.230912.2-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch" Version="0.24.230912.2-preview" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22272.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Updating the src/importmemories service to use SK v0.24.230912.2-preview

Several kernel builder/config methods have been deprecated/changed - updated to use latest/current as of at least v0.24

Also fixed/added missing textembeddingservice configuration for Azure Cognitive search section of memory import.  Azure Cognitive Search does not include an embeddings model, users/apps must create embedding first and as such the kernel should/must provide an embedding model/service to do so before saving to Azure Cognitive Search (https://learn.microsoft.com/en-us/azure/search/vector-search-how-to-generate-embeddings)